### PR TITLE
Added Translation "Deutsch (du)"

### DIFF
--- a/Locale/de_DE_du/translations.php
+++ b/Locale/de_DE_du/translations.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'Metadata'                                    => 'Metadaten',
+    'Key'                                         => 'Schlüssel',
+    'Value'                                       => 'Wert',
+    'No metadata'                                 => 'keine Metadaten vorhanden',
+    'Remove Metadata'                             => 'Metadaten löschen',
+    'Do you really want to remove this metadata?' => 'Willst du diese Metadaten wirklich löschen?',
+    'Add Metadata'                                => 'Metadaten hinzufügen',
+    'Custom Fields'                               => 'Benutzerdefinierte Felder', 
+    'Remove Metadata Task Field'                  => 'Benutzerdefiniertes Feld entfernen', 
+    'Options - comma seperated list for dropdown, radio, or checkbox group. 255 chars max.' => 'Optionen - kommagetrennte Liste für Dropdown-Liste, Radio oder Checkbox-Gruppe. 255 Zeichen max.',
+    'Attached Entity'                             => 'Angehängte Entität',
+    'No types have been defined yet.'             => 'Es wurden noch keine Typen definiert.',
+    'Field Name'                                  => 'Feldname',
+    'Type'                                        => 'Typen',
+    'Options'                                     => 'Optionen',
+    'Action'                                      => 'Aktion',
+];


### PR DESCRIPTION
With [this approved pull-request](https://github.com/kanboard/kanboard/pull/4767) the German translation will now come in 2 flavours.
This PR adds the new German flavour "Deutsch (du)" to the MetaMagik-Plugin