### PR TITLE
Set default textarea width to match the column width.

### DIFF
--- a/Assets/css/metamagik.css
+++ b/Assets/css/metamagik.css
@@ -2,6 +2,10 @@
 
 /*------ PAGE HEADER ------*/
 
-.metamagik-form-textarea {
+.task-form-main-column .metamagik-form-textarea {
+    width:700px;
+}
+
+.task-form-secondary-column .metamagik-form-textarea {
     width:auto;
 }


### PR DESCRIPTION
Fix for #77.  Makes MetaMagik textarea fields default to the width of the column they're in.  In column 1, we use the same width as the default for the 'description' textarea, which is set to an absolute 700px.  The other two columns follow the existing MetaMagik behavior and use 'auto' width.