### PR TITLE
Added class name to icon and counter on task

### DIFF
--- a/Template/task/footer_icon.php
+++ b/Template/task/footer_icon.php
@@ -1,7 +1,8 @@
 <?php
 if ($task['nb_metadata'] > 0):
 ?>
-        <span title="<?= t('Metadata') ?>" class="tooltip" data-href="<?= $this->url->href('MetadataController', 'task_footer', ['plugin' => 'metaMagik', 'task_id' => $task['id'], 'project_id' => $task['project_id']]) ?>">
+        <span title="<?= t('Metadata') ?>" class="tooltip metamagik-icon-count" data-href="<?= $this->url->href('MetadataController', 'task_footer', ['plugin' => 'metaMagik', 'task_id' => $task['id'], 'project_id' => $task['project_id']]) ?>">
             <i class="fa fa-plus-square-o fa-fw"></i><?= $task['nb_metadata'] ?>
         </span>
 <?php endif ?>
+


### PR DESCRIPTION
I've added a unique class name to the icon and counter span for metamagik on the task card. This is similar to other icons and information on the card.

e. g. task-icon-age oder task-priority

![grafik](https://user-images.githubusercontent.com/82320201/211167236-958e007d-255f-4cd7-9d3f-537230007ae6.png)

This allows to disable that on the task card via css or with the BoardCustomizer PlugIn (which has to be updated to provide this feature)

I will add that to the PlugIn after this has been pulled into the master.

Cheers, Fx

