### PR TITLE
Add new function isTypeDate

### DIFF
--- a/Model/MetadataTypeModel.php
+++ b/Model/MetadataTypeModel.php
@@ -38,7 +38,15 @@ class MetadataTypeModel extends Base
             ->eq('id', $id)
             ->findOne();
     }
-    
+
+    public function isTypeDate(string $name) : bool
+    {
+        $row = $this->db->table(self::TABLE)
+            ->eq('human_name', $name)
+            ->findOne();
+        return $row != null ? $row['data_type'] == 'date' : false;
+    }
+
     public function checkName($name, $id)
     {
         $test = $this->db->table(self::TABLE)


### PR DESCRIPTION
I refer to my [forum post](https://kanboard.discourse.group/t/mailmagik-dealing-with-task-dates/3235).

For extending my addition to Mailmagik date parsing, I need a new function to check whether a meta field is of type “date”.
Of course, I could insert such a function into Mailmagik, but I think MetaMagik is a much more suitable place.